### PR TITLE
Add hooping station row to warehouse map

### DIFF
--- a/index.html
+++ b/index.html
@@ -147,7 +147,8 @@
     <p id="thankYouMessage" style="display:none;">✅ Thank you! Your feedback has been submitted.</p>
   </div>
 
-  <script src="script.js"></script>
+  <!-- version query added to bust caches -->
+  <script src="script.js?v=2"></script>
   <script>
     // Theme bootstrap: restore persisted theme
     (function(){

--- a/script.js
+++ b/script.js
@@ -27,7 +27,13 @@ let inventoryData = [];
 let allCodes = [];
 
 const totalAisles = Object.keys(aisleConfig).length;
-svg.setAttribute("viewBox", `0 0 ${totalAisles * aisleSpacing} 550`);
+const maxBack = Math.max(...Object.values(aisleConfig).map(a => a.back));
+const hoopingStartY = backStartY + maxBack * (sectionSize + padding) + 40;
+// extend viewBox and explicit height so extra bottom row is visible
+const viewWidth = totalAisles * aisleSpacing;
+const viewHeight = hoopingStartY + sectionSize + 40;
+svg.setAttribute("viewBox", `0 0 ${viewWidth} ${viewHeight}`);
+svg.style.height = `${viewHeight}px`;
 
 async function loadInventoryData() {
   try {
@@ -147,6 +153,31 @@ function drawSections() {
       });
     }
   }
+
+  // Extra bottom row: Hooping Station
+  const hsLabel = document.createElementNS("http://www.w3.org/2000/svg", "text");
+  hsLabel.setAttribute("x", offsetX);
+  hsLabel.setAttribute("y", hoopingStartY + sectionSize - 4);
+  hsLabel.setAttribute("class", "aisle-label");
+  hsLabel.textContent = "Hooping Station";
+  svg.appendChild(hsLabel);
+
+  const hsStartX = offsetX + 110; // leave space for label
+  const hsSections = 6;
+  for (let i = 0; i < hsSections; i++) {
+    const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    rect.setAttribute("x", hsStartX + i * (sectionSize + padding));
+    rect.setAttribute("y", hoopingStartY);
+    rect.setAttribute("width", sectionSize);
+    rect.setAttribute("height", sectionSize);
+    rect.setAttribute("rx", 4);
+    rect.setAttribute("ry", 4);
+    rect.setAttribute("class", "section");
+    rect.setAttribute("data-key", `HS-AfterWalkway-Left-${i + 1}`);
+    rect.setAttribute("data-key-short", `HS-AfterWalkway-L-${i + 1}`);
+    svg.appendChild(rect);
+  }
+
   pulseLayer = null; // keep pulses above
   ensurePulseLayer();
 }


### PR DESCRIPTION
## Summary
- extend SVG map height to host an extra "Hooping Station" section
- render labeled Hooping Station row with six searchable blocks
- set explicit SVG height and cache-bust script tag so new row renders consistently

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68b2745b9fe083269fc086c73b680e85