### PR TITLE
Rework hooping station row layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,8 @@
     .section { fill: white; stroke: var(--map-line); stroke-width: 0.6; } /* outlines as original */
     .highlight { fill: var(--hi-fill) !important; stroke: var(--hi-stroke); stroke-width: 1.5; }
     .aisle-label { font-size: 11px; font-weight: bold; fill: var(--muted); }
+    .hooping-block { fill: #fff; stroke: #2196f3; stroke-width: 1; }
+    .hooping-text { fill: #2196f3; font-size: 11px; font-weight: bold; }
 
     .hint { font-size: 12px; color: var(--muted); margin-top: 6px; }
 
@@ -147,7 +149,8 @@
     <p id="thankYouMessage" style="display:none;">✅ Thank you! Your feedback has been submitted.</p>
   </div>
 
-  <script src="script.js"></script>
+  <!-- version query added to bust caches -->
+  <script src="script.js?v=4"></script>
   <script>
     // Theme bootstrap: restore persisted theme
     (function(){

--- a/script.js
+++ b/script.js
@@ -27,7 +27,13 @@ let inventoryData = [];
 let allCodes = [];
 
 const totalAisles = Object.keys(aisleConfig).length;
-svg.setAttribute("viewBox", `0 0 ${totalAisles * aisleSpacing} 550`);
+const maxBack = Math.max(...Object.values(aisleConfig).map(a => a.back));
+const hoopingStartY = backStartY + maxBack * (sectionSize + padding) + 40;
+// extend viewBox and explicit height so extra bottom row is visible
+const viewWidth = totalAisles * aisleSpacing;
+const viewHeight = hoopingStartY + sectionSize + 40;
+svg.setAttribute("viewBox", `0 0 ${viewWidth} ${viewHeight}`);
+svg.style.height = `${viewHeight}px`;
 
 async function loadInventoryData() {
   try {
@@ -147,6 +153,63 @@ function drawSections() {
       });
     }
   }
+
+  // Extra bottom row: Hooping Station block + surrounding sections
+  let hsX = offsetX;
+  let hsIndex = 1;
+  const addHsSection = x => {
+    const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+    rect.setAttribute("x", x);
+    rect.setAttribute("y", hoopingStartY);
+    rect.setAttribute("width", sectionSize);
+    rect.setAttribute("height", sectionSize);
+    rect.setAttribute("rx", 4);
+    rect.setAttribute("ry", 4);
+    rect.setAttribute("class", "section");
+    rect.setAttribute("data-key", `HS-AfterWalkway-Left-${hsIndex}`);
+    rect.setAttribute("data-key-short", `HS-AfterWalkway-L-${hsIndex}`);
+    svg.appendChild(rect);
+    hsIndex++;
+  };
+
+  // first 3 small blocks
+  for (let i = 0; i < 3; i++) {
+    addHsSection(hsX);
+    hsX += sectionSize + padding;
+  }
+
+  // big hooping station block
+  const bigWidth = (sectionSize + padding) * 4 - padding;
+  const bigRect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
+  bigRect.setAttribute("x", hsX);
+  bigRect.setAttribute("y", hoopingStartY);
+  bigRect.setAttribute("width", bigWidth);
+  bigRect.setAttribute("height", sectionSize);
+  bigRect.setAttribute("rx", 4);
+  bigRect.setAttribute("ry", 4);
+  bigRect.setAttribute("class", "hooping-block");
+  svg.appendChild(bigRect);
+
+  const hsText = document.createElementNS("http://www.w3.org/2000/svg", "text");
+  hsText.setAttribute("x", hsX + bigWidth / 2);
+  hsText.setAttribute("y", hoopingStartY + sectionSize / 2);
+  hsText.setAttribute("class", "hooping-text");
+  hsText.setAttribute("text-anchor", "middle");
+  hsText.setAttribute("dominant-baseline", "middle");
+  hsText.textContent = "Hooping Station";
+  svg.appendChild(hsText);
+
+  hsX += bigWidth + padding;
+
+  // next 3 small blocks
+  for (let i = 0; i < 3; i++) {
+    addHsSection(hsX);
+    hsX += sectionSize + padding;
+  }
+
+  // final single block
+  addHsSection(hsX);
+
   pulseLayer = null; // keep pulses above
   ensurePulseLayer();
 }


### PR DESCRIPTION
## Summary
- extend SVG to include hooping station row with labeled blue block
- style hooping station block with white fill, blue outline, and centered blue label
- bump script reference to v4 to force browser cache refresh

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2745b9fe083269fc086c73b680e85