### PR TITLE
Remove duplicate hooping styles

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,9 +91,7 @@
     .section { fill: white; stroke: var(--map-line); stroke-width: 0.6; } /* outlines as original */
     .highlight { fill: var(--hi-fill) !important; stroke: var(--hi-stroke); stroke-width: 1.5; }
     .aisle-label { font-size: 11px; font-weight: bold; fill: var(--muted); }
-    .hooping-block { fill: #fff; stroke: #2196f3; stroke-width: 1; }
-    .hooping-text { fill: #2196f3; font-size: 11px; font-weight: bold; }
-    .hooping-block { fill: #2196f3; stroke: #2196f3; }
+    .hooping-block { fill: #2196f3; stroke: #2196f3; stroke-width: 1; }
     .hooping-text { fill: #fff; font-size: 11px; font-weight: bold; }
 
     .hint { font-size: 12px; color: var(--muted); margin-top: 6px; }


### PR DESCRIPTION
## Summary
- remove duplicate `.hooping-block` and `.hooping-text` styles
- keep single definition with blue block and white text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a9f6fca483269eed57da3f30820b