### PR TITLE
Refactor Hooping Station section drawing

### DIFF
--- a/script.js
+++ b/script.js
@@ -160,20 +160,6 @@ function drawSections() {
   const addHsSection = x => {
     const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
     rect.setAttribute("x", x);
-    
-  // Extra bottom row: Hooping Station
-  const hsLabel = document.createElementNS("http://www.w3.org/2000/svg", "text");
-  hsLabel.setAttribute("x", offsetX);
-  hsLabel.setAttribute("y", hoopingStartY + sectionSize - 4);
-  hsLabel.setAttribute("class", "aisle-label");
-  hsLabel.textContent = "Hooping Station";
-  svg.appendChild(hsLabel);
-
-  const hsStartX = offsetX + 110; // leave space for label
-  const hsSections = 6;
-  for (let i = 0; i < hsSections; i++) {
-    const rect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
-    rect.setAttribute("x", hsStartX + i * (sectionSize + padding));
     rect.setAttribute("y", hoopingStartY);
     rect.setAttribute("width", sectionSize);
     rect.setAttribute("height", sectionSize);
@@ -185,6 +171,21 @@ function drawSections() {
     svg.appendChild(rect);
     hsIndex++;
   };
+
+  // Hooping Station label
+  const hsLabel = document.createElementNS("http://www.w3.org/2000/svg", "text");
+  hsLabel.setAttribute("x", offsetX);
+  hsLabel.setAttribute("y", hoopingStartY + sectionSize - 4);
+  hsLabel.setAttribute("class", "aisle-label");
+  hsLabel.textContent = "Hooping Station";
+  svg.appendChild(hsLabel);
+
+  // Fixed six Hooping Station sections
+  const hsStartX = offsetX + 110; // leave space for label
+  const hsSections = 6;
+  for (let i = 0; i < hsSections; i++) {
+    addHsSection(hsStartX + i * (sectionSize + padding));
+  }
 
   // first 3 small blocks
   for (let i = 0; i < 3; i++) {
@@ -223,11 +224,6 @@ function drawSections() {
 
   // final single block
   addHsSection(hsX);
-
-    rect.setAttribute("data-key", `HS-AfterWalkway-Left-${i + 1}`);
-    rect.setAttribute("data-key-short", `HS-AfterWalkway-L-${i + 1}`);
-    svg.appendChild(rect);
-  }
 
   pulseLayer = null; // keep pulses above
   ensurePulseLayer();


### PR DESCRIPTION
## Summary
- Simplify `addHsSection` to create a single Hooping Station section with position, size, and key attributes
- Generate Hooping Station label and fixed six sections outside of `addHsSection`
- Remove stray code after final Hooping Station section creation

## Testing
- `node - <<'NODE' ... NODE`

------
https://chatgpt.com/codex/tasks/task_e_68b3a9f62e2483269fc4fb509faf42c1