### PR TITLE
Remove duplicate script tags in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,9 +152,7 @@
   </div>
 
   <!-- version query added to bust caches -->
-  <script src="script.js?v=4"></script>
-  <script src="script.js?v=3"></script>
-  <script src="script.js?v=2"></script>
+    <script src="script.js?v=4"></script>
   <script>
     // Theme bootstrap: restore persisted theme
     (function(){


### PR DESCRIPTION
## Summary
- Remove redundant `script.js` includes from `index.html` leaving a single cache-busted reference

## Testing
- `python -m http.server 8000 >/tmp/http.log 2>&1 & pid=$!; sleep 2; curl -I http://localhost:8000/index.html; kill $pid; cat /tmp/http.log`
- `npx --yes -p puppeteer node - <<'NODE' ... NODE` *(fails: 403 Forbidden from npm registry)*

------
https://chatgpt.com/codex/tasks/task_e_68b3a9f3b0dc8326b2ba80fc428eb906