### PR TITLE
feat: make Hooping Station block spacing configurable

### DIFF
--- a/script.js
+++ b/script.js
@@ -12,8 +12,10 @@ const aisleConfig = {
 };
 
 const aisleSpacing = 55;
-const sectionSize = 20;
-const padding = 2;
+const sectionSize = 20; // width/height of individual blocks
+const padding = 2; // general gap used in aisle layout
+// spacing between Hooping Station blocks; adjust to increase gap
+const hoopingPadding = 6;
 const offsetX = 10;
 const topFrontY = 30;
 const backStartY = 220;
@@ -184,17 +186,17 @@ function drawSections() {
   const hsStartX = offsetX + 110; // leave space for label
   const hsSections = 6;
   for (let i = 0; i < hsSections; i++) {
-    addHsSection(hsStartX + i * (sectionSize + padding));
+    addHsSection(hsStartX + i * (sectionSize + hoopingPadding));
   }
 
   // first 3 small blocks
   for (let i = 0; i < 3; i++) {
     addHsSection(hsX);
-    hsX += sectionSize + padding;
+    hsX += sectionSize + hoopingPadding;
   }
 
   // big hooping station block
-  const bigWidth = (sectionSize + padding) * 4 - padding;
+  const bigWidth = (sectionSize + hoopingPadding) * 4 - hoopingPadding;
   const bigRect = document.createElementNS("http://www.w3.org/2000/svg", "rect");
   bigRect.setAttribute("x", hsX);
   bigRect.setAttribute("y", hoopingStartY);
@@ -214,12 +216,12 @@ function drawSections() {
   hsText.textContent = "Hooping Station";
   svg.appendChild(hsText);
 
-  hsX += bigWidth + padding;
+  hsX += bigWidth + hoopingPadding;
 
   // next 3 small blocks
   for (let i = 0; i < 3; i++) {
     addHsSection(hsX);
-    hsX += sectionSize + padding;
+    hsX += sectionSize + hoopingPadding;
   }
 
   // final single block


### PR DESCRIPTION
## Summary
- add `hoopingPadding` constant to control spacing around Hooping Station
- use `hoopingPadding` when positioning Hooping Station sections and central block

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3b1d491bc83268da151c09f0deb2c