### PR TITLE
Add numbered J aisle sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,7 @@
     .section { fill: white; stroke: var(--map-line); stroke-width: 0.6; } /* outlines as original */
     .highlight { fill: var(--hi-fill) !important; stroke: var(--hi-stroke); stroke-width: 1.5; }
     .aisle-label { font-size: 11px; font-weight: bold; fill: var(--muted); }
+    .section-label { font-size: 9px; font-weight: bold; fill: var(--muted); }
     .hooping-block { fill: #2196f3; stroke: #2196f3; stroke-width: 1; }
     .hooping-text { fill: #fff; font-size: 11px; font-weight: bold; }
 

--- a/script.js
+++ b/script.js
@@ -170,19 +170,22 @@ function drawSections() {
     rect.setAttribute("rx", 4);
     rect.setAttribute("ry", 4);
     rect.setAttribute("class", "section");
-    rect.setAttribute("data-key", `J-AfterWalkway-Left-${jIndex}`);
-    rect.setAttribute("data-key-short", `J-AfterWalkway-L-${jIndex}`);
+    rect.setAttribute("data-key", `J-AfterWalkway-Right-${jIndex}`);
+    rect.setAttribute("data-key-short", `J-AfterWalkway-R-${jIndex}`);
     svg.appendChild(rect);
+
+    // numeric labels so sections can be visually identified and searched
+    const t = document.createElementNS("http://www.w3.org/2000/svg", "text");
+    t.setAttribute("x", x + sectionSize / 2);
+    t.setAttribute("y", hoopingStartY + sectionSize / 2);
+    t.setAttribute("class", "section-label");
+    t.setAttribute("text-anchor", "middle");
+    t.setAttribute("dominant-baseline", "middle");
+    t.textContent = `J${jIndex}`;
+    svg.appendChild(t);
+
     jIndex++;
   };
-
-  // Label for aisle J
-  const jLabel = document.createElementNS("http://www.w3.org/2000/svg", "text");
-  jLabel.setAttribute("x", offsetX);
-  jLabel.setAttribute("y", hoopingStartY + sectionSize - 4);
-  jLabel.setAttribute("class", "aisle-label");
-  jLabel.textContent = "J";
-  svg.appendChild(jLabel);
 
   // Group 1 (A-Left, A-Right, B-Left)
   [["A",0],["A",1],["B",0]].forEach(([a,s]) => addJSection(colX(a,s)));


### PR DESCRIPTION
## Summary
- Label J aisle's bottom boxes with numeric identifiers for referencing and search results
- Assign J aisle sections as right-side to match inventory data and enable highlighting

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f89da3e083269308a3949d099073