### PR TITLE
Remove fixed SVG height to reduce whitespace

### DIFF
--- a/script.js
+++ b/script.js
@@ -30,11 +30,11 @@ let allCodes = [];
 const totalAisles = Object.keys(aisleConfig).length;
 const maxBack = Math.max(...Object.values(aisleConfig).map(a => a.back));
 const hoopingStartY = backStartY + maxBack * (sectionSize + padding) + 40;
-// extend viewBox and explicit height so extra bottom row is visible
+// extend viewBox so extra bottom row is visible
 const viewWidth = totalAisles * aisleSpacing;
 const viewHeight = hoopingStartY + sectionSize + 40;
 svg.setAttribute("viewBox", `0 0 ${viewWidth} ${viewHeight}`);
-svg.style.height = `${viewHeight}px`;
+// rely on CSS for height to avoid extra whitespace
 
 async function loadInventoryData() {
   try {


### PR DESCRIPTION
## Summary
- Drop explicit SVG height and rely on CSS to avoid extra bottom whitespace on the map.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b738072d1c8326a2739e6eebda3f25