### PR TITLE
Add feature notification popup

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,25 @@
     }
     .feedback-section button:hover { background-color: #27632a; }
     #thankYouMessage { margin-top: 15px; font-size: 16px; color: #2e7d32; font-weight: bold; }
+
+    /* Feature popup */
+    .feature-popup {
+      position: fixed;
+      bottom: 20px;
+      right: 20px;
+      max-width: 260px;
+      padding: 15px;
+      background: var(--card);
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+      text-align: left;
+      z-index: 1000;
+    }
+    .feature-popup.hidden { display: none; }
+    .feature-popup h3 { margin-top: 0; font-size: 16px; color: var(--muted); }
+    .feature-popup ul { padding-left: 20px; margin: 10px 0; }
+    .feature-popup li { margin-bottom: 6px; font-size: 14px; }
   </style>
 </head>
 <body>
@@ -116,6 +135,16 @@
   <div class="header">
     <img src="your-logo.png" alt="Logo" />
     <div class="header-title">Warehouse<br>Article Locator</div>
+  </div>
+
+  <div id="feature-popup" class="feature-popup hidden">
+    <h3>What's New</h3>
+    <ul>
+      <li>🌙 Dark mode — toggle at the top.</li>
+      <li>🔍 Advanced search shows results as you type.</li>
+      <li>🗺️ Coming soon: hat section J back of the warehouse.</li>
+    </ul>
+    <button id="feature-popup-dismiss" class="btn">Don't show again</button>
   </div>
 
   <div class="controls">
@@ -151,7 +180,7 @@
   </div>
 
   <!-- version query added to bust caches -->
-    <script src="script.js?v=5"></script>
+    <script src="script.js?v=6"></script>
   <script>
     // Theme bootstrap: restore persisted theme
     (function(){

--- a/script.js
+++ b/script.js
@@ -23,6 +23,7 @@ const svg = document.getElementById("aisles");
 const searchBox = document.getElementById("searchBox");
 const clearBtn = document.getElementById("clearBtn");
 const themeBtn = document.getElementById("themeToggle");
+const POPUP_VERSION = "1";
 
 let inventoryData = [];
 let allCodes = [];
@@ -339,6 +340,20 @@ if (themeBtn) {
   });
 }
 
+function initFeaturePopup() {
+  const stored = localStorage.getItem("featurePopupVersion");
+  if (stored === POPUP_VERSION) return;
+  const popup = document.getElementById("feature-popup");
+  const dismiss = document.getElementById("feature-popup-dismiss");
+  if (!popup || !dismiss) return;
+  popup.classList.remove("hidden");
+  dismiss.addEventListener("click", () => {
+    localStorage.setItem("featurePopupVersion", POPUP_VERSION);
+    popup.classList.add("hidden");
+  });
+}
+
 // Init
 drawSections();
 loadInventoryData();
+initFeaturePopup();


### PR DESCRIPTION
## Summary
- Introduce "What's New" popup highlighting dark mode, live search, and upcoming hat section J.
- Remember dismissal using `localStorage` so the popup only reappears when its version changes.
- Bump script version parameter for cache busting.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8aaad6fec8326a4e84c0a1636dcfd